### PR TITLE
fix(lsp): set textDocumentSync.save to false

### DIFF
--- a/src/lsp.cpp
+++ b/src/lsp.cpp
@@ -122,7 +122,7 @@ void LSPServer::OnInitialize(const json::object& data)
              {"change", 1}, // TextDocumentSyncKind.Full
              {"willSave", false},
              {"willSaveWaitUntil", false},
-             {"save", {{"includeText", false}}},
+             {"save", false},
          }},
     });
     m_outQueue.push(json::object(


### PR DESCRIPTION
I might be interpreting [the spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didSave) incorrectly, but to me it seems like if the server responds with the `SaveOptions` object it means it's interested in `textDocument/didSave` notifications.

The neovim client is running into some issues with that request, as it interprets it to be supported:

![](https://user-images.githubusercontent.com/6705160/148998131-8ce9c6a1-9db5-40cc-8bdc-594cc9000d5f.png)