### PR TITLE
Select the OpenCL device for building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,10 @@ target_include_directories(${TESTS_PROJECT_NAME}
      PRIVATE ${PROJECT_SOURCE_DIR}/lib/json/include
      PRIVATE ${PROJECT_SOURCE_DIR}/lib/logger/include
      PRIVATE ${PROJECT_SOURCE_DIR}/lib/catch/single_include
+     PRIVATE ${PROJECT_SOURCE_DIR}/lib/opencl/include
 )
+
+target_link_libraries (${TESTS_PROJECT_NAME} ${LIBS})
 
 target_compile_definitions(${TESTS_PROJECT_NAME} PRIVATE 
     CATCH_CONFIG_MAIN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ add_executable (${PROJECT_NAME} ${SOURCES} ${HEADERS})
 target_compile_definitions(${PROJECT_NAME} PRIVATE 
     BOOST_JSON_STANDALONE
     CL_SILENCE_DEPRECATION
-    VERSION="0.3"
+    VERSION="0.4"
 )
 
 target_include_directories(${PROJECT_NAME}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,5 +1,7 @@
 # OpenCL Language Server
 
+## Supported Capabilities:
+
 - [x] `textDocument/publishDiagnostics`
 
 ## Build
@@ -17,18 +19,42 @@ OpenCL Language Server requires OpenCL Runtime [[Intel](https://software.intel.c
 
 ## Parameters
 
-To enable server logging, pass the following options on the startup: `--enable-file-tracing --filename <path to the log file> --level <0-4>`
-
-You can also configure diagnostics with json-rpc request during the intitialization:
+You can configure diagnostics with `json-rpc` request during the intitialization:
 
 ```json
-"initializationOptions": {
-    "configuration": {
-        "buildOptions": [],
-        "maxNumberOfProblems": 100
+{
+    "jsonrpc": "2.0",
+    "id": 0,
+    "method": "initialize",
+    "params": {
+        "initializationOptions": {
+            "configuration": {
+                "buildOptions": [],
+                "deviceID": 0,
+                "maxNumberOfProblems": 100
+            }
+        }
     }
 }
 ```
+
+### Options
+
+* `buildOptions` - Build options to be used for building the program. The list of [supported](https://registry.khronos.org/OpenCL/sdk/2.1/docs/man/xhtml/clBuildProgram.html) build options.
+
+* `deviceID` - OpenCL device identifier or 0 (auto selection). 
+
+    *Run `./opencl-language-server --clinfo` to get information about available OpenCL devices including identifiers.*
+
+* `maxNumberOfProblems` - Controls the maximum number of problems produced by the language server.
+
+To enable file logging, pass the following parameters:
+
+```
+./opencl-language-server --enable-file-tracing --filename <path to the log file> --level <level [0-4]>
+```
+
+*Level: `0 - Trace, 1 - Debug, 2 - Info, 3 - Warn, 4 - Error`*
 
 ## Clients
 

--- a/include/clinfo.hpp
+++ b/include/clinfo.hpp
@@ -21,9 +21,9 @@ namespace vscode::opencl {
 struct ICLInfo
 {
     virtual ~ICLInfo() = default;
-    
+
     virtual boost::json::object json() = 0;
-    
+
     virtual uint32_t GetDeviceID(const cl::Device& device) = 0;
 
     virtual std::string GetDeviceDescription(const cl::Device& device) = 0;

--- a/include/clinfo.hpp
+++ b/include/clinfo.hpp
@@ -14,12 +14,19 @@
 #include <boost/json.hpp>
 #pragma warning(pop)
 
+#include "opencl.hpp"
+
 namespace vscode::opencl {
 
 struct ICLInfo
 {
     virtual ~ICLInfo() = default;
+    
     virtual boost::json::object json() = 0;
+    
+    virtual uint32_t GetDeviceID(const cl::Device& device) = 0;
+
+    virtual std::string GetDeviceDescription(const cl::Device& device) = 0;
 };
 
 std::shared_ptr<ICLInfo> CreateCLInfo();

--- a/include/clinfo.hpp
+++ b/include/clinfo.hpp
@@ -1,0 +1,27 @@
+//
+//  clinfo.hpp
+//  opencl-language-server
+//
+//  Created by is on 5.2.2023.
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#pragma warning(push, 0)
+#include <boost/json.hpp>
+#pragma warning(pop)
+
+namespace vscode::opencl {
+
+struct ICLInfo
+{
+    virtual ~ICLInfo() = default;
+    virtual boost::json::object json() = 0;
+};
+
+std::shared_ptr<ICLInfo> CreateCLInfo();
+
+} // namespace vscode::opencl

--- a/include/diagnostics.hpp
+++ b/include/diagnostics.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <clinfo.hpp>
+
 #include <memory>
 #include <string>
 
@@ -26,9 +28,10 @@ struct IDiagnostics
 {
     virtual void SetBuildOptions(const boost::json::array& options) = 0;
     virtual void SetMaxProblemsCount(int maxNumberOfProblems) = 0;
+    virtual void SetOpenCLDevice(uint32_t identifier) = 0;
     virtual boost::json::array Get(const Source& source) = 0;
 };
 
-std::shared_ptr<IDiagnostics> CreateDiagnostics();
+std::shared_ptr<IDiagnostics> CreateDiagnostics(std::shared_ptr<ICLInfo> clInfo);
 
 } // namespace vscode::opencl

--- a/include/jsonrpc.hpp
+++ b/include/jsonrpc.hpp
@@ -70,6 +70,7 @@ public:
      */
     void LogTrace(const std::string& message, const std::string& verbose = "");
     void WriteError(JsonRPC::ErrorCode errorCode, const std::string& message) const;
+
 private:
     void OnInitialize();
     void OnTracingChanged(const boost::json::object& data);

--- a/include/opencl.hpp
+++ b/include/opencl.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#define __CL_ENABLE_EXCEPTIONS
+#pragma warning(push, 0)
+#if defined(__APPLE__) || defined(__MACOSX) || defined(WIN32)
+    #include "opencl/cl.hpp"
+#else
+    #include <CL/cl.hpp>
+#endif
+#pragma warning(pop)

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -7,6 +7,10 @@
 
 #pragma once
 
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -16,5 +20,33 @@ std::string GenerateId();
 void Trim(std::string& s);
 std::vector<std::string> SplitString(const std::string& str, const std::string& pattern);
 std::string UriToPath(const std::string& uri);
+bool EndsWith(const std::string& str, const std::string& suffix);
+void RemoveNullTerminator(std::string& str);
+
+namespace internal {
+// Generates a lookup table for the checksums of all 8-bit values.
+std::array<std::uint_fast32_t, 256> GenerateCRCLookupTable();
+} // namespace internal
+
+// https://rosettacode.org/wiki/CRC-32#C++
+//
+// Calculates the CRC for any sequence of values.
+template <typename InputIterator>
+std::uint_fast32_t CRC32(InputIterator first, InputIterator last)
+{
+    // Generate lookup table only on first use then cache it - this is thread-safe.
+    static auto const table = internal::GenerateCRCLookupTable();
+
+    // Calculate the checksum - make sure to clip to 32 bits, for systems that don't
+    // have a true (fast) 32-bit type.
+    return std::uint_fast32_t {0xFFFFFFFFuL} &
+        ~std::accumulate(
+               first,
+               last,
+               ~std::uint_fast32_t {0} & std::uint_fast32_t {0xFFFFFFFFuL},
+               [](std::uint_fast32_t checksum, std::uint_fast8_t value) {
+                   return table[(checksum ^ value) & 0xFFu] ^ (checksum >> 8);
+               });
+}
 
 } // namespace vscode::opencl::utils

--- a/src/clinfo.cpp
+++ b/src/clinfo.cpp
@@ -1,0 +1,493 @@
+//
+//  clinfo.cpp
+//  opencl-language-server
+//
+//  Created by is on 5.2.2023.
+//
+
+#include "clinfo.hpp"
+#include "opencl.hpp"
+#include "utils.hpp"
+
+#include <array>
+#include <glogger.hpp>
+#include <unordered_map>
+
+using namespace boost;
+using namespace vscode::opencl::utils;
+using vscode::opencl::ICLInfo;
+
+namespace {
+
+constexpr const char TracePrefix[] = "#clinfo ";
+
+const std::unordered_map<cl_bool, std::string> booleanChoices {
+    {CL_TRUE, "CL_TRUE"},
+    {CL_FALSE, "CL_FALSE"},
+};
+const std::unordered_map<cl_bitfield, std::string> commandQueuePropertiesChoices {
+    {CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, "CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE"},
+    {CL_QUEUE_PROFILING_ENABLE, "CL_QUEUE_PROFILING_ENABLE"},
+};
+const std::unordered_map<cl_bitfield, std::string> deviceFPConfigChoices {
+    {CL_FP_DENORM, "CL_FP_DENORM"},
+    {CL_FP_INF_NAN, "CL_FP_INF_NAN"},
+    {CL_FP_ROUND_TO_NEAREST, "CL_FP_ROUND_TO_NEAREST"},
+    {CL_FP_ROUND_TO_ZERO, "CL_FP_ROUND_TO_ZERO"},
+    {CL_FP_ROUND_TO_INF, "CL_FP_ROUND_TO_INF"},
+    {CL_FP_FMA, "CL_FP_FMA"},
+};
+const std::unordered_map<cl_bitfield, std::string> deviceExecCapabilitiesChoices {
+    {CL_EXEC_KERNEL, "CL_EXEC_KERNEL"},
+    {CL_EXEC_NATIVE_KERNEL, "CL_EXEC_NATIVE_KERNEL"},
+};
+const std::unordered_map<cl_bitfield, std::string> deviceMemCacheTypeChoices {
+    {CL_NONE, "CL_NONE"}, {CL_READ_ONLY_CACHE, "CL_READ_ONLY_CACHE"}, {CL_READ_WRITE_CACHE, "CL_READ_WRITE_CACHE"}};
+const std::unordered_map<cl_bitfield, std::string> deviceLocalMemTypeChoices {
+    {CL_LOCAL, "CL_LOCAL"},
+    {CL_GLOBAL, "CL_GLOBAL"},
+};
+const std::unordered_map<cl_bitfield, std::string> deviceTypeChoices {
+    {CL_DEVICE_TYPE_CPU, "CL_DEVICE_TYPE_CPU"},
+    {CL_DEVICE_TYPE_GPU, "CL_DEVICE_TYPE_GPU"},
+    {CL_DEVICE_TYPE_ACCELERATOR, "CL_DEVICE_TYPE_ACCELERATOR"},
+    {CL_DEVICE_TYPE_DEFAULT, "CL_DEVICE_TYPE_DEFAULT"},
+};
+const std::unordered_map<intptr_t, std::string> devicePartitionPropertyChoices {
+    {CL_DEVICE_PARTITION_EQUALLY, "CL_DEVICE_PARTITION_EQUALLY"},
+    {CL_DEVICE_PARTITION_BY_COUNTS, "CL_DEVICE_PARTITION_BY_COUNTS"},
+    {CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN, "CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN"},
+};
+const std::unordered_map<cl_device_affinity_domain, std::string> deviceAffinityDomainChoices {
+    {CL_DEVICE_AFFINITY_DOMAIN_NUMA, "CL_DEVICE_AFFINITY_DOMAIN_NUMA"},
+    {CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE, "CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE"},
+    {CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE, "CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE"},
+    {CL_DEVICE_AFFINITY_DOMAIN_L2_CACHE, "CL_DEVICE_AFFINITY_DOMAIN_L2_CACHE"},
+    {CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE, "CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE"},
+    {CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE, "CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE"},
+};
+
+enum class PropertyType
+{
+    Boolean,
+    CommandQueueProperties,
+    DeviceAffinityDomain,
+    DeviceExecCapabilities,
+    DeviceFPConfig,
+    DeviceLocalMemType,
+    DeviceMemCacheType,
+    DeviceType,
+    Size,
+    String,
+    UnsignedInt,
+    UnsignedLong,
+    VectorOfSizes,
+    VectorOfDevicePartitionProperties
+};
+
+struct CLPlatformInfo
+{
+    cl_platform_info field;
+    std::string name;
+};
+
+struct CLDeviceInfo
+{
+    cl_device_info field;
+    std::string name;
+    PropertyType type;
+};
+
+std::array<CLPlatformInfo, 4> platformProperties {{
+    {CL_PLATFORM_NAME, "CL_PLATFORM_NAME"},
+    {CL_PLATFORM_VERSION, "CL_PLATFORM_VERSION"},
+    {CL_PLATFORM_VENDOR, "CL_PLATFORM_VENDOR"},
+    {CL_PLATFORM_PROFILE, "CL_PLATFORM_PROFILE"},
+}};
+
+std::array<CLDeviceInfo, 72> deviceProperties {{
+    {CL_DEVICE_ADDRESS_BITS, "CL_DEVICE_ADDRESS_BITS", PropertyType::UnsignedInt},
+    {CL_DEVICE_BUILT_IN_KERNELS, "CL_DEVICE_BUILT_IN_KERNELS", PropertyType::String},
+    {CL_DEVICE_AVAILABLE, "CL_DEVICE_AVAILABLE", PropertyType::Boolean},
+    {CL_DEVICE_COMPILER_AVAILABLE, "CL_DEVICE_COMPILER_AVAILABLE", PropertyType::Boolean},
+    {CL_DEVICE_DOUBLE_FP_CONFIG, "CL_DEVICE_DOUBLE_FP_CONFIG", PropertyType::DeviceFPConfig},
+    {CL_DEVICE_ENDIAN_LITTLE, "CL_DEVICE_ENDIAN_LITTLE", PropertyType::Boolean},
+    {CL_DEVICE_ERROR_CORRECTION_SUPPORT, "CL_DEVICE_ERROR_CORRECTION_SUPPORT", PropertyType::Boolean},
+    {CL_DEVICE_EXECUTION_CAPABILITIES, "CL_DEVICE_EXECUTION_CAPABILITIES", PropertyType::DeviceExecCapabilities},
+    {CL_DEVICE_EXTENSIONS, "CL_DEVICE_EXTENSIONS", PropertyType::String},
+    {CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, "CL_DEVICE_GLOBAL_MEM_CACHE_SIZE", PropertyType::UnsignedLong},
+    {CL_DEVICE_GLOBAL_MEM_CACHE_TYPE, "CL_DEVICE_GLOBAL_MEM_CACHE_TYPE", PropertyType::DeviceMemCacheType},
+    {CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE, "CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE", PropertyType::UnsignedInt},
+    {CL_DEVICE_GLOBAL_MEM_SIZE, "CL_DEVICE_GLOBAL_MEM_SIZE", PropertyType::UnsignedLong},
+    {CL_DEVICE_HOST_UNIFIED_MEMORY, "CL_DEVICE_HOST_UNIFIED_MEMORY", PropertyType::Boolean},
+    {CL_DEVICE_IMAGE_SUPPORT, "CL_DEVICE_IMAGE_SUPPORT", PropertyType::Boolean},
+    {CL_DEVICE_IMAGE_MAX_BUFFER_SIZE, "CL_DEVICE_IMAGE_MAX_BUFFER_SIZE", PropertyType::Size},
+    {CL_DEVICE_IMAGE_MAX_ARRAY_SIZE, "CL_DEVICE_IMAGE_MAX_ARRAY_SIZE", PropertyType::Size},
+    {CL_DEVICE_IMAGE_PITCH_ALIGNMENT, "CL_DEVICE_IMAGE_PITCH_ALIGNMENT", PropertyType::UnsignedInt},
+    {CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT, "CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT", PropertyType::UnsignedInt},
+    {CL_DEVICE_IMAGE2D_MAX_HEIGHT, "CL_DEVICE_IMAGE2D_MAX_HEIGHT", PropertyType::Size},
+    {CL_DEVICE_IMAGE2D_MAX_WIDTH, "CL_DEVICE_IMAGE2D_MAX_WIDTH", PropertyType::Size},
+    {CL_DEVICE_IMAGE3D_MAX_DEPTH, "CL_DEVICE_IMAGE3D_MAX_DEPTH", PropertyType::Size},
+    {CL_DEVICE_IMAGE3D_MAX_HEIGHT, "CL_DEVICE_IMAGE3D_MAX_HEIGHT", PropertyType::Size},
+    {CL_DEVICE_IMAGE3D_MAX_WIDTH, "CL_DEVICE_IMAGE3D_MAX_WIDTH", PropertyType::Size},
+    {CL_DEVICE_LOCAL_MEM_SIZE, "CL_DEVICE_LOCAL_MEM_SIZE", PropertyType::Size},
+    {CL_DEVICE_LOCAL_MEM_TYPE, "CL_DEVICE_LOCAL_MEM_TYPE", PropertyType::UnsignedLong},
+    {CL_DEVICE_MAX_CLOCK_FREQUENCY, "CL_DEVICE_MAX_CLOCK_FREQUENCY", PropertyType::UnsignedInt},
+    {CL_DEVICE_MAX_COMPUTE_UNITS, "CL_DEVICE_MAX_COMPUTE_UNITS", PropertyType::UnsignedInt},
+    {CL_DEVICE_MAX_CONSTANT_ARGS, "CL_DEVICE_MAX_CONSTANT_ARGS", PropertyType::UnsignedInt},
+    {CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE, "CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE", PropertyType::UnsignedLong},
+    {CL_DEVICE_MAX_MEM_ALLOC_SIZE, "CL_DEVICE_MAX_MEM_ALLOC_SIZE", PropertyType::UnsignedLong},
+    {CL_DEVICE_MAX_PARAMETER_SIZE, "CL_DEVICE_MAX_PARAMETER_SIZE", PropertyType::Size},
+    {CL_DEVICE_MAX_READ_IMAGE_ARGS, "CL_DEVICE_MAX_READ_IMAGE_ARGS", PropertyType::UnsignedInt},
+    {CL_DEVICE_MAX_SAMPLERS, "CL_DEVICE_MAX_SAMPLERS", PropertyType::UnsignedInt},
+    {CL_DEVICE_MAX_WORK_GROUP_SIZE, "CL_DEVICE_MAX_WORK_GROUP_SIZE", PropertyType::Size},
+    {CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, "CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS", PropertyType::UnsignedInt},
+    {CL_DEVICE_MAX_WORK_ITEM_SIZES, "CL_DEVICE_MAX_WORK_ITEM_SIZES", PropertyType::VectorOfSizes},
+    {CL_DEVICE_MAX_WRITE_IMAGE_ARGS, "CL_DEVICE_MAX_WRITE_IMAGE_ARGS", PropertyType::UnsignedInt},
+    {CL_DEVICE_MEM_BASE_ADDR_ALIGN, "CL_DEVICE_MEM_BASE_ADDR_ALIGN", PropertyType::UnsignedInt},
+    {CL_DEVICE_NAME, "CL_DEVICE_NAME", PropertyType::String},
+    {CL_DEVICE_LINKER_AVAILABLE, "CL_DEVICE_LINKER_AVAILABLE", PropertyType::Boolean},
+    {CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR, "CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR", PropertyType::UnsignedInt},
+    {CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT, "CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT", PropertyType::UnsignedInt},
+    {CL_DEVICE_NATIVE_VECTOR_WIDTH_INT, "CL_DEVICE_NATIVE_VECTOR_WIDTH_INT", PropertyType::UnsignedInt},
+    {CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG, "CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG", PropertyType::UnsignedInt},
+    {CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT, "CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT", PropertyType::UnsignedInt},
+    {CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE, "CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE", PropertyType::UnsignedInt},
+    {CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF, "CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF", PropertyType::UnsignedInt},
+    {CL_DEVICE_OPENCL_C_VERSION, "CL_DEVICE_OPENCL_C_VERSION", PropertyType::String},
+    {CL_DEVICE_PARTITION_MAX_SUB_DEVICES, "CL_DEVICE_PARTITION_MAX_SUB_DEVICES", PropertyType::UnsignedInt},
+    {CL_DEVICE_PARTITION_PROPERTIES, "CL_DEVICE_PARTITION_PROPERTIES", PropertyType::VectorOfDevicePartitionProperties},
+    {CL_DEVICE_PARTITION_AFFINITY_DOMAIN, "CL_DEVICE_PARTITION_AFFINITY_DOMAIN", PropertyType::DeviceAffinityDomain},
+    {CL_DEVICE_PARTITION_TYPE, "CL_DEVICE_PARTITION_TYPE", PropertyType::VectorOfDevicePartitionProperties},
+    {CL_DEVICE_PREFERRED_INTEROP_USER_SYNC, "CL_DEVICE_PREFERRED_INTEROP_USER_SYNC", PropertyType::Boolean},
+    {CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR, "CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR", PropertyType::UnsignedInt},
+    {CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT, "CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT", PropertyType::UnsignedInt},
+    {CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT, "CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT", PropertyType::UnsignedInt},
+    {CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG, "CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG", PropertyType::UnsignedInt},
+    {CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT, "CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT", PropertyType::UnsignedInt},
+    {CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE, "CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE", PropertyType::UnsignedInt},
+    {CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF, "CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF", PropertyType::UnsignedInt},
+    {CL_DEVICE_PRINTF_BUFFER_SIZE, "CL_DEVICE_PRINTF_BUFFER_SIZE", PropertyType::Size},
+    {CL_DEVICE_PROFILE, "CL_DEVICE_PROFILE", PropertyType::String},
+    {CL_DEVICE_PROFILING_TIMER_RESOLUTION, "CL_DEVICE_PROFILING_TIMER_RESOLUTION", PropertyType::Size},
+    {CL_DEVICE_REFERENCE_COUNT, "CL_DEVICE_REFERENCE_COUNT", PropertyType::UnsignedInt},
+    {CL_DEVICE_QUEUE_PROPERTIES, "CL_DEVICE_QUEUE_PROPERTIES", PropertyType::DeviceLocalMemType},
+    {CL_DEVICE_SINGLE_FP_CONFIG, "CL_DEVICE_SINGLE_FP_CONFIG", PropertyType::DeviceFPConfig},
+    {CL_DEVICE_TYPE, "CL_DEVICE_TYPE", PropertyType::DeviceType},
+    {CL_DEVICE_VENDOR, "CL_DEVICE_VENDOR", PropertyType::String},
+    {CL_DEVICE_VENDOR_ID, "CL_DEVICE_VENDOR_ID", PropertyType::UnsignedInt},
+    {CL_DEVICE_VERSION, "CL_DEVICE_VERSION", PropertyType::String},
+    {CL_DRIVER_VERSION, "CL_DRIVER_VERSION", PropertyType::String},
+}};
+
+json::array GetStringsArrayFromBitfield(cl_bitfield value, const std::unordered_map<cl_bitfield, std::string>& options)
+{
+    json::array values;
+    for (auto& [bitfield, label] : options)
+    {
+        if (value & bitfield)
+        {
+            values.emplace_back(label);
+        }
+    }
+    return values;
+}
+
+json::string GetStringFromEnum(cl_bitfield value, const std::unordered_map<cl_bitfield, std::string>& options)
+{
+    json::array values;
+    for (auto& [bitfield, label] : options)
+    {
+        if (value == bitfield)
+        {
+            return {label};
+        }
+    }
+    return "unknown";
+}
+
+json::array GetExtensions(const std::string& strExtensions)
+{
+    auto extensions = SplitString(strExtensions, " ");
+    return json::array(extensions.begin(), extensions.end());
+}
+
+json::array GetKernels(const std::string& strKernels)
+{
+    auto kernels = SplitString(strKernels, ";");
+    if (kernels.size() == 1 && kernels.front().empty())
+    {
+        return {};
+    }
+    return json::array(kernels.begin(), kernels.end());
+}
+
+json::object GetDeviceJSONInfo(const cl::Device& device)
+{
+    json::object info;
+    for (auto& property : deviceProperties)
+    {
+        try
+        {
+            switch (property.type)
+            {
+                case PropertyType::UnsignedInt:
+                {
+                    cl_uint value = 0;
+                    device.getInfo(property.field, &value);
+                    info[property.name] = value;
+                    break;
+                }
+                case PropertyType::Boolean:
+                {
+                    cl_bool value = 0;
+                    device.getInfo(property.field, &value);
+                    info[property.name] = booleanChoices.at(value);
+                    break;
+                }
+                case PropertyType::DeviceFPConfig:
+                {
+                    cl_bitfield value = 0;
+                    device.getInfo(property.field, &value);
+                    info[property.name] = GetStringsArrayFromBitfield(value, deviceFPConfigChoices);
+                    break;
+                }
+                case PropertyType::DeviceExecCapabilities:
+                {
+                    cl_bitfield value = 0;
+                    device.getInfo(property.field, &value);
+                    info[property.name] = GetStringsArrayFromBitfield(value, deviceFPConfigChoices);
+                    break;
+                }
+                case PropertyType::String:
+                {
+                    std::string value;
+                    device.getInfo(property.field, &value);
+                    RemoveNullTerminator(value);
+                    if (property.name == "CL_DEVICE_EXTENSIONS")
+                    {
+                        info[property.name] = GetExtensions(value);
+                    }
+                    else if (property.name == "CL_DEVICE_BUILT_IN_KERNELS")
+                    {
+                        info[property.name] = GetKernels(value);
+                    }
+                    else
+                    {
+                        info[property.name] = value;
+                    }
+                    break;
+                }
+                case PropertyType::UnsignedLong:
+                {
+                    cl_ulong value = 0;
+                    device.getInfo(property.field, &value);
+                    info[property.name] = value;
+                    break;
+                }
+                case PropertyType::DeviceMemCacheType:
+                {
+                    cl_bitfield value = 0;
+                    device.getInfo(property.field, &value);
+                    info[property.name] = GetStringFromEnum(value, deviceMemCacheTypeChoices);
+                    break;
+                }
+                case PropertyType::Size:
+                {
+                    std::size_t value = 0;
+                    device.getInfo(property.field, &value);
+                    info[property.name] = value;
+                    break;
+                }
+                case PropertyType::VectorOfSizes:
+                {
+                    std::vector<std::size_t> values;
+                    device.getInfo(property.field, &values);
+                    info[property.name] = json::array(values.begin(), values.end());
+                    break;
+                }
+                case PropertyType::DeviceLocalMemType:
+                {
+                    cl_bitfield value = 0;
+                    device.getInfo(property.field, &value);
+                    info[property.name] = GetStringFromEnum(value, deviceLocalMemTypeChoices);
+                    break;
+                }
+                case PropertyType::CommandQueueProperties:
+                {
+                    cl_bitfield value = 0;
+                    device.getInfo(property.field, &value);
+                    info[property.name] = GetStringsArrayFromBitfield(value, commandQueuePropertiesChoices);
+                    break;
+                }
+                case PropertyType::DeviceType:
+                {
+                    cl_bitfield value = 0;
+                    device.getInfo(property.field, &value);
+                    info[property.name] = GetStringsArrayFromBitfield(value, deviceTypeChoices);
+                    break;
+                }
+                case PropertyType::VectorOfDevicePartitionProperties:
+                {
+                    std::vector<cl_device_partition_property> values;
+                    device.getInfo(property.field, &values);
+                    json::array partitionProperties;
+                    for (auto property : values)
+                    {
+                        if (property != 0)
+                        {
+                            partitionProperties.emplace_back(devicePartitionPropertyChoices.at(property));
+                        }
+                    }
+                    info[property.name] = partitionProperties;
+                    break;
+                }
+                case PropertyType::DeviceAffinityDomain:
+                {
+                    cl_bitfield value = 0;
+                    device.getInfo(property.field, &value);
+                    info[property.name] = GetStringsArrayFromBitfield(value, deviceAffinityDomainChoices);
+                    break;
+                }
+            }
+        }
+        catch (const cl::Error& err)
+        {
+            GLogWarn(TracePrefix, "Failed to get info for the device, ", err.what(), " (", err.err(), ")");
+            continue;
+        }
+    }
+    return info;
+}
+
+uint32_t CalculateDeviceID(const cl::Device& device)
+{
+    try
+    {
+        const auto name = device.getInfo<CL_DEVICE_NAME>();
+        const auto type = device.getInfo<CL_DEVICE_TYPE>();
+        const auto version = device.getInfo<CL_DEVICE_VERSION>();
+        const auto vendor = device.getInfo<CL_DEVICE_VENDOR>();
+        const auto vendorID = device.getInfo<CL_DEVICE_VENDOR_ID>();
+        const auto driverVersion = device.getInfo<CL_DRIVER_VERSION>();
+        const auto identifier =
+            name + std::to_string(type) + version + vendor + std::to_string(vendorID) + driverVersion;
+        return CRC32(identifier.begin(), identifier.end());
+    }
+    catch (const cl::Error& err)
+    {
+        GLogWarn(TracePrefix, "Failed to calculate device uuid, ", err.what(), " (", err.err(), ")");
+    }
+    return 0;
+}
+
+json::array GetDevicesJSONInfo(const std::vector<cl::Device>& devices)
+{
+    json::array jsonDevices;
+    for (auto& device : devices)
+    {
+        auto info = GetDeviceJSONInfo(device);
+        info["DEVICE_ID"] = CalculateDeviceID(device);
+        jsonDevices.push_back(info);
+    }
+    return jsonDevices;
+}
+
+uint32_t CalculatePlatformID(const cl::Platform& platform)
+{
+    try
+    {
+        const auto name = platform.getInfo<CL_PLATFORM_NAME>();
+        const auto version = platform.getInfo<CL_PLATFORM_VERSION>();
+        const auto vendor = platform.getInfo<CL_PLATFORM_VENDOR>();
+        const auto profile = platform.getInfo<CL_PLATFORM_PROFILE>();
+        const auto identifier = name + version + vendor + profile;
+        return CRC32(identifier.begin(), identifier.end());
+    }
+    catch (const cl::Error& err)
+    {
+        GLogWarn(TracePrefix, "Failed to calculate device uuid, ", err.what(), " (", err.err(), ")");
+    }
+    return 0;
+}
+
+json::object GetPlatformJSONInfo(const cl::Platform& platform)
+{
+    json::object info;
+    for (auto& property : platformProperties)
+    {
+        try
+        {
+            std::string value;
+            platform.getInfo(property.field, &value);
+            RemoveNullTerminator(value);
+            info[property.name] = value;
+        }
+        catch (const cl::Error& err)
+        {
+            GLogWarn(TracePrefix, "Failed to get info for a platform, ", err.what(), " (", err.err(), ")");
+        }
+    }
+
+    info["PLATFORM_ID"] = CalculatePlatformID(platform);
+
+    auto extensions = platform.getInfo<CL_PLATFORM_EXTENSIONS>();
+    RemoveNullTerminator(extensions);
+    info["CL_PLATFORM_EXTENSIONS"] = GetExtensions(extensions);
+
+    try
+    {
+        std::vector<cl::Device> devices;
+        platform.getDevices(CL_DEVICE_TYPE_ALL, &devices);
+        info["DEVICES"] = GetDevicesJSONInfo(devices);
+    }
+    catch (const cl::Error& err)
+    {
+        GLogWarn(TracePrefix, "Failed to get devices for a platform, ", err.what(), " (", err.err(), ")");
+    }
+
+    return info;
+}
+
+class CLInfo final : public ICLInfo
+{
+public:
+    json::object json()
+    {
+        GLogTrace(TracePrefix, "Searching for OpenCL platforms...");
+        std::vector<cl::Platform> platforms;
+        try
+        {
+            cl::Platform::get(&platforms);
+        }
+        catch (const cl::Error& err)
+        {
+            GLogError(TracePrefix, "No OpenCL platforms were found, ", err.what(), " (", err.err(), ")");
+        }
+
+        GLogInfo(TracePrefix, "Found OpenCL platforms: ", platforms.size());
+        if (platforms.size() == 0)
+        {
+            return {};
+        }
+
+        std::vector<json::object> jsonPlatforms;
+        for (auto& platform : platforms)
+        {
+            jsonPlatforms.emplace_back(GetPlatformJSONInfo(platform));
+        }
+
+        return json::object {{"PLATFORMS", jsonPlatforms}};
+    }
+};
+
+} // namespace
+
+namespace vscode::opencl {
+
+std::shared_ptr<ICLInfo> CreateCLInfo()
+{
+    return std::shared_ptr<ICLInfo>(new CLInfo());
+}
+
+} // namespace vscode::opencl

--- a/src/clinfo.cpp
+++ b/src/clinfo.cpp
@@ -6,7 +6,6 @@
 //
 
 #include "clinfo.hpp"
-#include "opencl.hpp"
 #include "utils.hpp"
 
 #include <array>
@@ -364,14 +363,18 @@ uint32_t CalculateDeviceID(const cl::Device& device)
 {
     try
     {
-        const auto name = device.getInfo<CL_DEVICE_NAME>();
-        const auto type = device.getInfo<CL_DEVICE_TYPE>();
-        const auto version = device.getInfo<CL_DEVICE_VERSION>();
-        const auto vendor = device.getInfo<CL_DEVICE_VENDOR>();
-        const auto vendorID = device.getInfo<CL_DEVICE_VENDOR_ID>();
-        const auto driverVersion = device.getInfo<CL_DRIVER_VERSION>();
-        const auto identifier =
-            name + std::to_string(type) + version + vendor + std::to_string(vendorID) + driverVersion;
+        auto name = device.getInfo<CL_DEVICE_NAME>();
+        auto type = device.getInfo<CL_DEVICE_TYPE>();
+        auto version = device.getInfo<CL_DEVICE_VERSION>();
+        auto vendor = device.getInfo<CL_DEVICE_VENDOR>();
+        auto vendorID = device.getInfo<CL_DEVICE_VENDOR_ID>();
+        auto driverVersion = device.getInfo<CL_DRIVER_VERSION>();
+        auto identifier = std::move(name)
+                        + std::to_string(type)
+                        + std::move(version)
+                        + std::move(vendor)
+                        + std::to_string(vendorID)
+                        + std::move(driverVersion);
         return CRC32(identifier.begin(), identifier.end());
     }
     catch (const cl::Error& err)
@@ -478,6 +481,32 @@ public:
         }
 
         return json::object {{"PLATFORMS", jsonPlatforms}};
+    }
+        
+    uint32_t GetDeviceID(const cl::Device& device)
+    {
+        return CalculateDeviceID(device);
+    }
+
+    std::string GetDeviceDescription(const cl::Device& device)
+    {
+        auto name = device.getInfo<CL_DEVICE_NAME>();
+        auto type = device.getInfo<CL_DEVICE_TYPE>();
+        auto version = device.getInfo<CL_DEVICE_VERSION>();
+        auto vendor = device.getInfo<CL_DEVICE_VENDOR>();
+        auto vendorID = device.getInfo<CL_DEVICE_VENDOR_ID>();
+        auto driverVersion = device.getInfo<CL_DRIVER_VERSION>();
+        RemoveNullTerminator(name);
+        RemoveNullTerminator(version);
+        RemoveNullTerminator(vendor);
+        RemoveNullTerminator(driverVersion);
+        auto description = "name: " + std::move(name) + "; "
+                         + "type: " + std::to_string(type) + "; "
+                         + "version: " + std::move(version) + "; "
+                         + "vendor: " + std::move(vendor) + "; "
+                         + "vendorID: " + std::to_string(vendorID) + "; "
+                         + "driverVersion: " + std::move(driverVersion);
+        return description;
     }
 };
 

--- a/src/clinfo.cpp
+++ b/src/clinfo.cpp
@@ -369,12 +369,8 @@ uint32_t CalculateDeviceID(const cl::Device& device)
         auto vendor = device.getInfo<CL_DEVICE_VENDOR>();
         auto vendorID = device.getInfo<CL_DEVICE_VENDOR_ID>();
         auto driverVersion = device.getInfo<CL_DRIVER_VERSION>();
-        auto identifier = std::move(name)
-                        + std::to_string(type)
-                        + std::move(version)
-                        + std::move(vendor)
-                        + std::to_string(vendorID)
-                        + std::move(driverVersion);
+        auto identifier = std::move(name) + std::to_string(type) + std::move(version) + std::move(vendor) +
+            std::to_string(vendorID) + std::move(driverVersion);
         return CRC32(identifier.begin(), identifier.end());
     }
     catch (const cl::Error& err)
@@ -482,7 +478,7 @@ public:
 
         return json::object {{"PLATFORMS", jsonPlatforms}};
     }
-        
+
     uint32_t GetDeviceID(const cl::Device& device)
     {
         return CalculateDeviceID(device);
@@ -500,12 +496,9 @@ public:
         RemoveNullTerminator(version);
         RemoveNullTerminator(vendor);
         RemoveNullTerminator(driverVersion);
-        auto description = "name: " + std::move(name) + "; "
-                         + "type: " + std::to_string(type) + "; "
-                         + "version: " + std::move(version) + "; "
-                         + "vendor: " + std::move(vendor) + "; "
-                         + "vendorID: " + std::to_string(vendorID) + "; "
-                         + "driverVersion: " + std::move(driverVersion);
+        auto description = "name: " + std::move(name) + "; " + "type: " + std::to_string(type) + "; " +
+            "version: " + std::move(version) + "; " + "vendor: " + std::move(vendor) + "; " +
+            "vendorID: " + std::to_string(vendorID) + "; " + "driverVersion: " + std::move(driverVersion);
         return description;
     }
 };

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -252,6 +252,7 @@ boost::json::array Diagnostics::Get(const Source& source)
     }
 
     buildLog = BuildSource(source.text);
+    utils::RemoveNullTerminator(buildLog);
     GLogTrace(TracePrefix, "BuildLog:\n", buildLog);
 
     return BuildDiagnostics(buildLog, srcName);

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -79,8 +79,7 @@ private:
     int m_maxNumberOfProblems = 100;
 };
 
-Diagnostics::Diagnostics(std::shared_ptr<ICLInfo> clInfo)
-    : m_clInfo { std::move(clInfo) }
+Diagnostics::Diagnostics(std::shared_ptr<ICLInfo> clInfo) : m_clInfo {std::move(clInfo)}
 {
     SetOpenCLDevice(0);
 }
@@ -99,14 +98,15 @@ void Diagnostics::SetOpenCLDevice(uint32_t identifier)
     }
 
     GLogInfo(TracePrefix, "Found OpenCL platforms: ", platforms.size());
-    if(platforms.size() == 0)
+    if (platforms.size() == 0)
     {
         return;
     }
-    
+
     std::string description;
     std::optional<cl::Device> selectedDevice;
-    for (auto& platform : platforms) {
+    for (auto& platform : platforms)
+    {
         std::vector<cl::Device> devices;
         try
         {
@@ -117,11 +117,11 @@ void Diagnostics::SetOpenCLDevice(uint32_t identifier)
             GLogError(TracePrefix, "No OpenCL devices were found, ", err.what(), " (", err.err(), ")");
         }
         GLogInfo(TracePrefix, "Found OpenCL devices: ", devices.size());
-        if(devices.size() == 0)
+        if (devices.size() == 0)
         {
             return;
         }
-        
+
         size_t maxPowerIndex = 0;
         GLogTrace(TracePrefix, "Selecting OpenCL device (total:", devices.size(), ")...");
         for (auto& device : devices)
@@ -131,10 +131,13 @@ void Diagnostics::SetOpenCLDevice(uint32_t identifier)
             {
                 description = m_clInfo->GetDeviceDescription(device);
                 auto deviceID = m_clInfo->GetDeviceID(device);
-                if(identifier == deviceID) {
+                if (identifier == deviceID)
+                {
                     selectedDevice = device;
                     break;
-                } else {
+                }
+                else
+                {
                     powerIndex = GetDevicePowerIndex(device);
                 }
             }
@@ -143,7 +146,7 @@ void Diagnostics::SetOpenCLDevice(uint32_t identifier)
                 GLogWarn(TracePrefix, "Failed to get info for a device, ", err.what(), " (", err.err(), ")");
                 continue;
             }
-            
+
             if (powerIndex > maxPowerIndex)
             {
                 maxPowerIndex = powerIndex;
@@ -157,12 +160,12 @@ void Diagnostics::SetOpenCLDevice(uint32_t identifier)
 
 std::string Diagnostics::BuildSource(const std::string& source) const
 {
-    if(!m_device.has_value())
+    if (!m_device.has_value())
     {
         throw std::runtime_error("missing OpenCL device");
     }
-    
-    std::vector<cl::Device> ds { *m_device };
+
+    std::vector<cl::Device> ds {*m_device};
     cl::Context context(ds, NULL, NULL, NULL);
     cl::Program program;
     try
@@ -236,18 +239,18 @@ boost::json::array Diagnostics::BuildDiagnostics(const std::string& buildLog, co
 
 boost::json::array Diagnostics::Get(const Source& source)
 {
-    if(!m_device.has_value())
+    if (!m_device.has_value())
     {
         throw std::runtime_error("missing OpenCL device");
     }
-    
+
     GLogDebug(TracePrefix, "Getting diagnostics...");
     std::string buildLog;
     std::string srcName;
 
     if (!source.filePath.empty())
     {
-        auto filePath = std::filesystem::path(source.filePath).string();  
+        auto filePath = std::filesystem::path(source.filePath).string();
         srcName = std::filesystem::path(filePath).filename().string();
     }
 

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -6,6 +6,7 @@
 //
 
 #include "diagnostics.hpp"
+#include "opencl.hpp"
 #include "utils.hpp"
 
 #include <iostream>
@@ -14,16 +15,6 @@
 
 #include <glogger.hpp>
 #include <filesystem.hpp>
-
-#define __CL_ENABLE_EXCEPTIONS
-#pragma warning(push, 0)
-#if defined(__APPLE__) || defined(__MACOSX) || defined(WIN32)
-    #include "opencl/cl.hpp"
-#else
-    #include <CL/cl.hpp>
-#endif
-#pragma warning(pop)
-
 
 using namespace boost;
 

--- a/src/jsonrpc.cpp
+++ b/src/jsonrpc.cpp
@@ -13,9 +13,9 @@ using namespace boost;
 namespace vscode::opencl {
 
 namespace {
-    constexpr char TracePrefix[] = "#jrpc ";
-    constexpr char LE[] = "\r\n";
-}
+constexpr char TracePrefix[] = "#jrpc ";
+constexpr char LE[] = "\r\n";
+} // namespace
 
 void JsonRPC::RegisterMethodCallback(const std::string& method, InputCallbackFunc&& func)
 {

--- a/src/jsonrpc.cpp
+++ b/src/jsonrpc.cpp
@@ -183,7 +183,7 @@ void JsonRPC::OnInitialize()
         m_initialized = true;
         GLogDebug(
             TracePrefix,
-            "Tracing options: is verbose",
+            "Tracing options: is verbose: ",
             m_verbosity ? "yes" : "no",
             ", is on: ",
             m_tracing ? "yes" : "no");

--- a/src/lsp.cpp
+++ b/src/lsp.cpp
@@ -154,9 +154,9 @@ void LSPServer::OnInitialized(const json::object& data)
         {"id", utils::GenerateId()},
         {"method", "workspace/didChangeConfiguration"},
     }});
-    json::array params({{
+    json::object params({
         {"registrations", registrations},
-    }});
+    });
     m_outQueue.push(json::object(
         {
             {"id", utils::GenerateId()},

--- a/src/lsp.cpp
+++ b/src/lsp.cpp
@@ -253,7 +253,7 @@ void LSPServer::OnConfiguration(const json::object& data)
 
         auto maxProblemsCount = result.at(1).as_int64();
         m_diagnostics->SetMaxProblemsCount(static_cast<int>(maxProblemsCount));
-        
+
         auto deviceID = result.at(2).as_int64();
         m_diagnostics->SetOpenCLDevice(static_cast<uint32_t>(deviceID));
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,13 +18,13 @@
 #pragma warning(pop)
 
 #ifndef VERSION
-#error version is required
+    #error version is required
 #endif
 
-#if defined(WIN32)    
-#include <stdio.h>
-#include <fcntl.h>
-#include <io.h>
+#if defined(WIN32)
+    #include <stdio.h>
+    #include <fcntl.h>
+    #include <io.h>
 #endif
 
 using namespace vscode::opencl;
@@ -34,20 +34,20 @@ char* getArgOption(char** begin, char** end, const char* option);
 
 int main(int argc, char* argv[])
 {
-    if(isArgOption(argv, argv + argc, "--version"))
+    if (isArgOption(argv, argv + argc, "--version"))
     {
         std::cout << VERSION << std::endl;
         exit(0);
     }
-    
-    if(isArgOption(argv, argv + argc, "--clinfo"))
+
+    if (isArgOption(argv, argv + argc, "--clinfo"))
     {
         auto clinfo = CreateCLInfo();
         auto jsonBody = clinfo->json();
         std::cout << boost::json::serialize(boost::json::value_from(jsonBody)) << std::endl;
         exit(0);
     }
-    
+
     const bool shouldLogTofile = isArgOption(argv, argv + argc, "--enable-file-tracing");
     char* filename = getArgOption(argv, argv + argc, "--filename");
     char* levelStr = getArgOption(argv, argv + argc, "--level");
@@ -62,7 +62,7 @@ int main(int argc, char* argv[])
         GLogger::instance().SetMinLevel(GLogger::Output::File, level);
     }
 
-    
+
 #if defined(WIN32)
     // to handle CRLF
     if (_setmode(_fileno(stdin), _O_BINARY) == -1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 
 #include "lsp.hpp"
+#include "clinfo.hpp"
 
 #define __glogger_implementation__ // define this only once
 #include <glogger.hpp>
@@ -36,6 +37,14 @@ int main(int argc, char* argv[])
     if(isArgOption(argv, argv + argc, "--version"))
     {
         std::cout << VERSION << std::endl;
+        exit(0);
+    }
+    
+    if(isArgOption(argv, argv + argc, "--clinfo"))
+    {
+        auto clinfo = CreateCLInfo();
+        auto jsonBody = clinfo->json();
+        std::cout << boost::json::serialize(boost::json::value_from(jsonBody)) << std::endl;
         exit(0);
     }
     


### PR DESCRIPTION
* Add an option to get information about OpenCL devices

   The information is printed to the standard output as JSON string.
   
   * It contains only properties defined in OpenCL 1.2.
   * `DEVICE_ID` is  calculated as `CRC32(<CL_DEVICE_NAME>+<CL_DEVICE_TYPE>+<CL_DEVICE_VERSION>+<CL_DEVICE_VENDOR>+<CL_DEVICE_VENDOR_ID>+<CL_DRIVER_VERSION>)`
   * `PLATFORM_ID` is calculated as `CRC32(<CL_PLATFORM_NAME>+<CL_PLATFORM_VERSION>+<CL_PLATFORM_VENDOR>+<CL_PLATFORM_PROFILE>)`

* Add support for OpenCL device selection

* Fix OnInitialized handler

   Object is expected instead of an array.

* Fix log message
* Remove extra null terminator at the end of the build log
* Format sources
* Bumped version to 0.4