### PR TITLE
Use ubuntu-20.04 instead of ubuntu-latest 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
           - os: macos-latest
           - os: windows-latest
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ add_executable (${PROJECT_NAME} ${SOURCES} ${HEADERS})
 target_compile_definitions(${PROJECT_NAME} PRIVATE 
     BOOST_JSON_STANDALONE
     CL_SILENCE_DEPRECATION
-    VERSION="0.4"
+    VERSION="0.4.1"
 )
 
 target_include_directories(${PROJECT_NAME}


### PR DESCRIPTION
`ubuntu-latest` is Ubuntu 22.04 since November 9, 2022