### PR TITLE
fix (device selection): make it check other platforms

### DIFF
--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -119,7 +119,7 @@ void Diagnostics::SetOpenCLDevice(uint32_t identifier)
         spdlog::get(logger)->info("Found OpenCL devices: {}", devices.size());
         if (devices.size() == 0)
         {
-            return;
+            continue;
         }
 
         size_t maxPowerIndex = 0;


### PR DESCRIPTION
This is something I noticed due to having Mesa's OpenCL installed and they did not have any devices. 

This the lang server to error saying there was not device due to it ignoring the other platforms.
This was fixed by just substituting the `return` inside the **if statement** of `Diagnostics::SetOpenCLDevice`.

Please accept this bug fix. Thank you for your time.