### PR TITLE
`--clinfo` bugfix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,15 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+    paths-ignore:
+      - '*.md'
   pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '*.md'
 
 jobs:
   build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.17)
+cmake_minimum_required (VERSION 3.16)
 
 file(READ "version" VERSION_OUTPUT)
 string(STRIP ${VERSION_OUTPUT} PACKAGE_VERSION)

--- a/conanfile.py
+++ b/conanfile.py
@@ -68,10 +68,16 @@ class OpenCLLanguageServerConanfile(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
+        build_folder = (
+            os.path.join(self.build_folder, str(self.settings.build_type))
+            if self.settings.os == "Windows"
+            else self.build_folder
+        )
+        bin_ext = ".exe" if self.settings.os == "Windows" else ""
         copy(
             self,
-            "opencl-language-server",
-            self.build_folder,
+            f"opencl-language-server{bin_ext}",
+            build_folder,
             os.path.join(self.package_folder, "bin"),
         )
         copy(

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -21,7 +21,6 @@ void Trim(std::string& s);
 std::vector<std::string> SplitString(const std::string& str, const std::string& pattern);
 std::string UriToPath(const std::string& uri);
 bool EndsWith(const std::string& str, const std::string& suffix);
-void RemoveNullTerminator(std::string& str);
 
 namespace internal {
 // Generates a lookup table for the checksums of all 8-bit values.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+wheel
 conan >= 2.0

--- a/src/clinfo.cpp
+++ b/src/clinfo.cpp
@@ -261,7 +261,6 @@ json::object_t GetDeviceJSONInfo(const cl::Device& device)
                 {
                     std::string value;
                     device.getInfo(property.field, &value);
-                    RemoveNullTerminator(value);
                     if (property.name == "CL_DEVICE_EXTENSIONS")
                     {
                         info[property.name] = GetExtensions(value);
@@ -418,7 +417,6 @@ json GetPlatformJSONInfo(const cl::Platform& platform)
         {
             std::string value;
             platform.getInfo(property.field, &value);
-            RemoveNullTerminator(value);
             info[property.name] = value;
         }
         catch (const cl::Error& err)
@@ -430,7 +428,6 @@ json GetPlatformJSONInfo(const cl::Platform& platform)
     info["PLATFORM_ID"] = CalculatePlatformID(platform);
 
     auto extensions = platform.getInfo<CL_PLATFORM_EXTENSIONS>();
-    RemoveNullTerminator(extensions);
     info["CL_PLATFORM_EXTENSIONS"] = GetExtensions(extensions);
 
     try
@@ -491,10 +488,6 @@ public:
         auto vendor = device.getInfo<CL_DEVICE_VENDOR>();
         auto vendorID = device.getInfo<CL_DEVICE_VENDOR_ID>();
         auto driverVersion = device.getInfo<CL_DRIVER_VERSION>();
-        RemoveNullTerminator(name);
-        RemoveNullTerminator(version);
-        RemoveNullTerminator(vendor);
-        RemoveNullTerminator(driverVersion);
         auto description = "name: " + std::move(name) + "; " + "type: " + std::to_string(type) + "; " +
             "version: " + std::move(version) + "; " + "vendor: " + std::move(vendor) + "; " +
             "vendorID: " + std::to_string(vendorID) + "; " + "driverVersion: " + std::move(driverVersion);

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -255,7 +255,6 @@ nlohmann::json Diagnostics::Get(const Source& source)
     }
 
     buildLog = BuildSource(source.text);
-    utils::RemoveNullTerminator(buildLog);
     spdlog::get(logger)->trace("BuildLog:\n", buildLog);
 
     return BuildDiagnostics(buildLog, srcName);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -94,14 +94,6 @@ bool EndsWith(const std::string& str, const std::string& suffix)
     return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
 }
 
-void RemoveNullTerminator(std::string& str)
-{
-    if (EndsWith(str, "\0"))
-    {
-        str.pop_back();
-    }
-}
-
 namespace internal {
 // Generates a lookup table for the checksums of all 8-bit values.
 std::array<std::uint_fast32_t, 256> GenerateCRCLookupTable()

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -17,18 +17,15 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not can_run(self):
-            return        
-        
-        if self.settings.os == "Windows":
-            return  # TODO: Fix "'opencl-language-server.exe' is not recognized as an internal or external command, operable program or batch file."
-        
+            return
+
         bin_ext = ".exe" if self.settings.os == "Windows" else ""
         opencl_ls = f"opencl-language-server{bin_ext}"
 
         output = StringIO()
         self.run(f"{opencl_ls} --version", output)
         assert len(output.getvalue()) > 0
-        
+
         output = StringIO()
         self.run(f"{opencl_ls} --clinfo", output)
         clinfo = json.loads(output.getvalue())


### PR DESCRIPTION
* Delete RemoveNullTerminator function

   This is an outdated workaround that currently causes an assertion failure for empty strings.
   It is no longer required with updated dependencies.

* Set cmake_minimum_required to 3.16
* Add wheel to requirements.txt
* Fix conan package creation in Windows
* Update triggers of the build workflow