### PR TITLE
Add libclang dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,3 +76,6 @@ jobs:
     - name: Conan Create
       run: |
         python3 build.py conan-create
+
+# TODO: cache prebuilt libraries like in 
+# https://github.com/cristianadam/qt5/blob/eb958d8c1a9d22ebc94502fc30d56e77dbebb580/.github/workflows/qmake_build.yml#L83

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,9 +73,5 @@ jobs:
         cd .build
         ctest --verbose --output-on-failure
 
-    - name: Conan Create
-      run: |
-        python3 build.py conan-create
-
 # TODO: cache prebuilt libraries like in 
 # https://github.com/cristianadam/qt5/blob/eb958d8c1a9d22ebc94502fc30d56e77dbebb580/.github/workflows/qmake_build.yml#L83

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,15 @@ jobs:
       run: |
         python3 build.py conan-install --with-tests
     
+    - name: Cache libclang
+      id: cache-libclang
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-libclang
+      with:
+        path: .build/_deps/libclang-subbuild/libclang-populate-prefix/src/*.7z
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('libclang/libclang-urls.txt') }}
+
     - name: Configure
       run: |
         python3 build.py configure --with-tests
@@ -72,6 +81,3 @@ jobs:
       run: |
         cd .build
         ctest --verbose --output-on-failure
-
-# TODO: cache prebuilt libraries like in 
-# https://github.com/cristianadam/qt5/blob/eb958d8c1a9d22ebc94502fc30d56e77dbebb580/.github/workflows/qmake_build.yml#L83

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,13 +71,24 @@ jobs:
           pip3 install -r requirements.txt
           conan profile detect
 
+      # The following step is copied from the build.yml.
+      # TODO: reuse it
+      - name: Cache libclang
+        id: cache-libclang
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-libclang
+        with:
+          path: .build/_deps/libclang-subbuild/libclang-populate-prefix/src/*.7z
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('libclang/libclang-urls.txt') }}
+
 
       - name: Windows - Configure & Build (Release)
         if: "contains(matrix.config.os, 'windows')"
         run: |
-          python3 build.py conan-install -pr:h=profiles/windows.release.x86_64
-          python3 build.py configure -t .conan-install/build/generators/conan_toolchain.cmake -bt Release
-          python3 build.py build -bt Release
+          python3 build.py conan-install
+          python3 build.py configure
+          python3 build.py build
 
       - name: Windows - Archive Artifact
         if: "contains(matrix.config.os, 'windows')"
@@ -100,8 +111,8 @@ jobs:
       - name: Linux - Configure & Build (Release)
         if: "contains(matrix.config.os, 'ubuntu')"
         run: |
-          ./build.py conan-install -pr:h=profiles/linux.release.x86_64
-          ./build.py configure -t .conan-install/build/Release/generators/conan_toolchain.cmake -bt Release
+          ./build.py conan-install
+          ./build.py configure
           ./build.py build
 
       - name: Linux - Archive Artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@ if(MSVC)
     add_compile_options(/WX /W4 /EHsc)
 else()
     add_compile_options(-Wall -Wextra -Wpedantic -Wimplicit-fallthrough -Werror)
+    if(LINUX)
+        # Prebuilt Clang and LLVM static libraries are position-dependent 
+        add_link_options(-no-pie)
+    endif()
 endif()
 
 message(STATUS "Build Configuration")
@@ -48,6 +52,8 @@ find_package(spdlog REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(CLI11 REQUIRED)
 find_package(uriparser REQUIRED)
+
+add_subdirectory(libclang)
 
 if(ENABLE_TESTING)
     find_package(GTest REQUIRED)
@@ -79,13 +85,13 @@ list(TRANSFORM sources PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/src/")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/version.hpp.in version.hpp)
 source_group("include" FILES ${headers})
 source_group("src" FILES ${sources})
-set(libs nlohmann_json::nlohmann_json spdlog::spdlog OpenCL::HeadersCpp CLI11::CLI11 uriparser::uriparser)
+set(conan_libs nlohmann_json::nlohmann_json spdlog::spdlog OpenCL::HeadersCpp CLI11::CLI11 uriparser::uriparser)
 if(LINUX)
-    set(libs ${libs} stdc++fs OpenCL::OpenCL)
+    set(conan_libs ${conan_libs} stdc++fs OpenCL::OpenCL)
 elseif(APPLE)
-    set(libs ${libs} ${OpenCL_LIBRARIES})
+    set(conan_libs ${conan_libs} ${OpenCL_LIBRARIES})
 elseif(WIN32)
-    set(libs ${libs} OpenCL::OpenCL)
+    set(conan_libs ${conan_libs} OpenCL::OpenCL)
 endif()
 
 add_executable (${PROJECT_NAME} ${sources} ${headers})
@@ -107,7 +113,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 endif()
 
 
-target_link_libraries(${PROJECT_NAME} ${libs})
+target_link_libraries(${PROJECT_NAME} ${conan_libs} libclang-imported)
 target_include_directories(${PROJECT_NAME} PRIVATE 
     "${PROJECT_SOURCE_DIR}/include"
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/builder/actions/defaults.py
+++ b/builder/actions/defaults.py
@@ -14,7 +14,7 @@ class Defaults(object):
     machine = _uname.machine.lower()
     debug_build_type = "Debug"
     release_build_type = "Release"
-    default_build_types = debug_build_type
+    default_build_types = release_build_type
     supported_build_types = [debug_build_type, release_build_type]
     output_folder = ".conan-install"
     build_folder = ".build"

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,8 +17,8 @@ class OpenCLLanguageServerConanfile(ConanFile):
     topics = ("opencl", "language-server")
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeToolchain", "CMakeDeps"
-    options = {"fPIC": [True, False], "enable_testing": [True, False]}
-    default_options = {"fPIC": True, "enable_testing": False}
+    options = {"enable_testing": [True, False]}
+    default_options = {"enable_testing": False}
     requires = (
         "cli11/[^2.3.2]",
         "nlohmann_json/[^3.11.2]",
@@ -28,6 +28,7 @@ class OpenCLLanguageServerConanfile(ConanFile):
     )
     exports_sources = (
         "include/**",
+        "libclang/**",
         "src/**",
         "tests/**",
         "CMakeLists.txt",
@@ -49,10 +50,6 @@ class OpenCLLanguageServerConanfile(ConanFile):
 
     def validate(self):
         check_min_cppstd(self, 17)
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
 
     def layout(self):
         cmake_layout(self)

--- a/include/log.hpp
+++ b/include/log.hpp
@@ -5,6 +5,8 @@
 //  Created by Ilia Shoshin on 20/08/23.
 //
 
+#pragma once
+
 #include <string>
 #include <spdlog/spdlog.h>
 

--- a/libclang/CMakeLists.txt
+++ b/libclang/CMakeLists.txt
@@ -24,27 +24,42 @@ if(DEFINED LLVM_ROOT_DIR AND NOT LLVM_ROOT_DIR STREQUAL "")
 else()
 
   # Download prebuilt static llvm & clang libraries
-
   include(FetchContent)
   set(FETCHCONTENT_QUIET OFF)
 
-  if(APPLE)
-    set(LIBCLANG_URL "https://download.qt.io/development_releases/prebuilt/libclang/qt/libclang-release_15.0.0-based-mac.7z")
-    set(LIBCLANG_HASH "8a944b4b65d2dca883fe539af5e5eef9a67e2abca91b28258fb08c46e3bb05b6")
-  elseif(WIN32)
-    set(LIBCLANG_URL "https://download.qt.io/development_releases/prebuilt/libclang/qt/libclang-release_15.0.0-based-windows-vs2019_64.7z")
-    set(LIBCLANG_HASH "3cd73b31be503ec7281f1f8907f95392d1c8bd0a8c2c92c39dc177f8c3d02baf")
-  else()
-    set(LIBCLANG_URL "https://download.qt.io/development_releases/prebuilt/libclang/qt/libclang-release_15.0.0-based-linux-Ubuntu20.04-gcc9.3-x86_64.7z")
-    set(LIBCLANG_HASH "0cfdf3387b8917e99fbd81358a142daeb3bcb84c107c96f1508f257ee2082bda")
-  endif()
+  file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/libclang-urls.txt libclang_entries)
+
+  message(STATUS "Parsing ${CMAKE_CURRENT_SOURCE_DIR}/libclang-urls.txt...")
+  foreach(entry ${libclang_entries})
+    # Parse platform, URL, and hash
+    list(GET entry 0 platform)
+    list(GET entry 1 url_value)
+    list(GET entry 2 hash_value)
+
+    if(platform STREQUAL "APPLE" AND APPLE)
+      set(libclang_url ${url_value})
+      set(libclang_hash ${hash_value})
+      break()
+    elseif(platform STREQUAL "WIN32" AND WIN32)
+      set(libclang_url ${url_value})
+      set(libclang_hash ${hash_value})
+      break()
+    elseif(platform STREQUAL "LINUX" AND LINUX)
+      set(libclang_url ${url_value})
+      set(libclang_hash ${hash_value})
+      break()
+    endif()
+  endforeach()
+
+  message(STATUS "LIBCLANG URL: ${libclang_url}")
+  message(STATUS "LIBCLANG HASH: ${libclang_hash}")
 
   FetchContent_Declare(libclang
       SOURCE_DIR prebuild
       DOWNLOAD_EXTRACT_TIMESTAMP TRUE
       TLS_VERIFY TRUE
-      URL ${LIBCLANG_URL}
-      URL_HASH SHA256=${LIBCLANG_HASH}
+      URL ${libclang_url}
+      URL_HASH SHA256=${libclang_hash}
     )
     FetchContent_MakeAvailable(libclang)
     set(LLVM_ROOT_DIR ${libclang_SOURCE_DIR})

--- a/libclang/CMakeLists.txt
+++ b/libclang/CMakeLists.txt
@@ -2,33 +2,12 @@
 # add_subdirectory(libclang)
 # target_link_libraries(${TARGET} libclang-imported)
 
-if(WIN32)
-  if(CMAKE_VS_PLATFORM_NAME STREQUAL "x64")
-    set(DIA_PLATFORM_NAME "amd64")
-  else()
-    set(DIA_PLATFORM_NAME "")
-  endif()
-
-  find_library(
-    diasdk_lib
-    NAMES diaguids.lib
-    PATH_SUFFIXES "lib/${DIA_PLATFORM_NAME}"
-    HINTS "$ENV{VSINSTALLDIR}/DIA SDK" "${CMAKE_GENERATOR_INSTANCE}/DIA SDK")
-
-  message(STATUS "diasdk_lib: ${diasdk_lib}")
-endif()
-
 # Define -DLLVM_ROOT_DIR=<path> if you have previously downloaded libclang manually
 if(DEFINED LLVM_ROOT_DIR AND NOT LLVM_ROOT_DIR STREQUAL "")
   # LLVM_ROOT_DIR is already defined
 else()
-
   # Download prebuilt static llvm & clang libraries
-  include(FetchContent)
-  set(FETCHCONTENT_QUIET OFF)
-
   file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/libclang-urls.txt libclang_entries)
-
   message(STATUS "Parsing ${CMAKE_CURRENT_SOURCE_DIR}/libclang-urls.txt...")
   foreach(entry ${libclang_entries})
     # Parse platform, URL, and hash
@@ -54,6 +33,9 @@ else()
   message(STATUS "LIBCLANG URL: ${libclang_url}")
   message(STATUS "LIBCLANG HASH: ${libclang_hash}")
 
+  include(FetchContent)
+  set(FETCHCONTENT_QUIET OFF)
+
   FetchContent_Declare(libclang
       SOURCE_DIR prebuild
       DOWNLOAD_EXTRACT_TIMESTAMP TRUE
@@ -76,10 +58,21 @@ include(ClangConfig)
 
 if(WIN32)
   # Workaround to replace the hardcoded path to diaguids.lib
-  
-  if(EXISTS ${diasdk_lib})
-    # Pass
+  if(CMAKE_VS_PLATFORM_NAME STREQUAL "x64")
+    set(DIA_PLATFORM_NAME "amd64")
   else()
+    set(DIA_PLATFORM_NAME "")
+  endif()
+
+  find_library(
+    diasdk_lib
+    NAMES diaguids.lib
+    PATH_SUFFIXES "lib/${DIA_PLATFORM_NAME}"
+    HINTS "$ENV{VSINSTALLDIR}/DIA SDK" "${CMAKE_GENERATOR_INSTANCE}/DIA SDK")
+
+  message(STATUS "diasdk_lib: ${diasdk_lib}")
+
+  if(NOT EXISTS ${diasdk_lib})
     message(FATAL_ERROR "The file ${diasdk_lib} does not exist")
   endif()
   
@@ -94,7 +87,6 @@ if(WIN32)
   )
   message(STATUS "LLVMDebugInfoPDB: ${link_libraries}")
 endif()
-
 
 message(STATUS "LLVM targets to build: ${LLVM_TARGETS_TO_BUILD}")
 message(STATUS "LLVM native arch: ${LLVM_NATIVE_ARCH}")

--- a/libclang/CMakeLists.txt
+++ b/libclang/CMakeLists.txt
@@ -1,0 +1,125 @@
+# Usage: 
+# add_subdirectory(libclang)
+# target_link_libraries(${TARGET} libclang-imported)
+
+if(WIN32)
+  if(CMAKE_VS_PLATFORM_NAME STREQUAL "x64")
+    set(DIA_PLATFORM_NAME "amd64")
+  else()
+    set(DIA_PLATFORM_NAME "")
+  endif()
+
+  find_library(
+    diasdk_lib
+    NAMES diaguids.lib
+    PATH_SUFFIXES "lib/${DIA_PLATFORM_NAME}"
+    HINTS "$ENV{VSINSTALLDIR}/DIA SDK" "${CMAKE_GENERATOR_INSTANCE}/DIA SDK")
+
+  message(STATUS "diasdk_lib: ${diasdk_lib}")
+endif()
+
+# Define -DLLVM_ROOT_DIR=<path> if you have previously downloaded libclang manually
+if(DEFINED LLVM_ROOT_DIR AND NOT LLVM_ROOT_DIR STREQUAL "")
+  # LLVM_ROOT_DIR is already defined
+else()
+
+  # Download prebuilt static llvm & clang libraries
+
+  include(FetchContent)
+  set(FETCHCONTENT_QUIET OFF)
+
+  if(APPLE)
+    set(LIBCLANG_URL "https://download.qt.io/development_releases/prebuilt/libclang/qt/libclang-release_15.0.0-based-mac.7z")
+    set(LIBCLANG_HASH "8a944b4b65d2dca883fe539af5e5eef9a67e2abca91b28258fb08c46e3bb05b6")
+  elseif(WIN32)
+    set(LIBCLANG_URL "https://download.qt.io/development_releases/prebuilt/libclang/qt/libclang-release_15.0.0-based-windows-vs2019_64.7z")
+    set(LIBCLANG_HASH "3cd73b31be503ec7281f1f8907f95392d1c8bd0a8c2c92c39dc177f8c3d02baf")
+  else()
+    set(LIBCLANG_URL "https://download.qt.io/development_releases/prebuilt/libclang/qt/libclang-release_15.0.0-based-linux-Ubuntu20.04-gcc9.3-x86_64.7z")
+    set(LIBCLANG_HASH "0cfdf3387b8917e99fbd81358a142daeb3bcb84c107c96f1508f257ee2082bda")
+  endif()
+
+  FetchContent_Declare(libclang
+      SOURCE_DIR prebuild
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+      TLS_VERIFY TRUE
+      URL ${LIBCLANG_URL}
+      URL_HASH SHA256=${LIBCLANG_HASH}
+    )
+    FetchContent_MakeAvailable(libclang)
+    set(LLVM_ROOT_DIR ${libclang_SOURCE_DIR})
+
+endif()
+
+message(STATUS "LLVM root directory: ${LLVM_ROOT_DIR}")
+
+set(cmake_llvm "${LLVM_ROOT_DIR}/lib/cmake/llvm")
+set(cmake_clang "${LLVM_ROOT_DIR}/lib/cmake/clang")
+list(APPEND CMAKE_MODULE_PATH ${cmake_llvm} ${cmake_clang})
+include(LLVMConfig)
+include(ClangConfig)
+
+if(WIN32)
+  # Workaround to replace the hardcoded path to diaguids.lib
+  
+  if(EXISTS ${diasdk_lib})
+    # Pass
+  else()
+    message(FATAL_ERROR "The file ${diasdk_lib} does not exist")
+  endif()
+  
+  get_target_property(link_libraries LLVMDebugInfoPDB INTERFACE_LINK_LIBRARIES)
+  list(FIND link_libraries "C:/Program Files (x86)/Microsoft Visual Studio/2019/Professional/DIA SDK/lib/amd64/diaguids.lib" index)
+  if(index GREATER -1)
+    list(REMOVE_AT link_libraries ${index})
+    list(INSERT link_libraries ${index} "${diasdk_lib}")
+  endif()
+  set_target_properties(LLVMDebugInfoPDB PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${link_libraries}"
+  )
+  message(STATUS "LLVMDebugInfoPDB: ${link_libraries}")
+endif()
+
+
+message(STATUS "LLVM targets to build: ${LLVM_TARGETS_TO_BUILD}")
+message(STATUS "LLVM native arch: ${LLVM_NATIVE_ARCH}")
+message(STATUS "LLVM include directories: ${LLVM_INCLUDE_DIRS}")
+message(STATUS "LLVM definitions: ${LLVM_DEFINITIONS}")
+message(STATUS "LLVM assertions: ${LLVM_ENABLE_ASSERTIONS}")
+message(STATUS "LLVM eh: ${LLVM_ENABLE_EH}")
+message(STATUS "LLVM rtti: ${LLVM_ENABLE_RTTI}")
+
+# Prepare the list of definitions before passing them to the INTERFACE_COMPILE_DEFINITIONS property
+separate_arguments(llvm_definitions_list NATIVE_COMMAND ${LLVM_DEFINITIONS})
+foreach(definition ${llvm_definitions_list})
+  # Remove the prefix -D from the current definition
+  string(REGEX REPLACE "^-D" "" new_definition ${definition})
+  # Replace the current definition with the new definition (without the "-D' prefix)
+  list(APPEND new_llvm_definitions ${new_definition})
+endforeach()
+set(llvm_definitions_list ${new_llvm_definitions})
+
+if(WIN32)
+  # Import functions from static library, not from DLL
+  list(APPEND llvm_definitions_list "CINDEX_NO_EXPORTS")
+endif()
+
+message(STATUS "LLVM parsed definitions: ${llvm_definitions_list}")
+
+set(llvm_components ${LLVM_NATIVE_ARCH} ${LLVM_NATIVE_ARCH}TargetMCA core)
+llvm_map_components_to_libnames(llvm_libs ${llvm_components})
+set(clang_libraries clangAnalysis clangAnalysisFlowSensitive clangAnalysisFlowSensitiveModels clangAPINotes clangARCMigrate clangAST clangASTMatchers clangBasic clangCodeGen clangCrossTU clangDependencyScanning clangDirectoryWatcher clangDriver clangDynamicASTMatchers clangEdit clangExtractAPI clangFormat clangFrontend clangFrontendTool clangHandleCXX clangHandleLLVM clangIndex clangIndexSerialization clangInterpreter clangLex clangParse clangRewrite clangRewriteFrontend clangSema clangSerialization clangStaticAnalyzerCheckers clangStaticAnalyzerCore clangStaticAnalyzerFrontend clangSupport clangTooling clangToolingASTDiff clangToolingCore clangToolingInclusions clangToolingRefactoring clangToolingSyntax clangTransformer)
+
+message(STATUS "LLVM libraries: ${llvm_libs}")
+message(STATUS "CLANG libraries: ${clang_libraries}")
+set(deps_libs ${llvm_libs})
+list(APPEND deps_libs ${clang_libraries})
+
+add_library(libclang-imported STATIC IMPORTED GLOBAL)
+set_target_properties(libclang-imported 
+  PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${LLVM_INCLUDE_DIRS}"
+  INTERFACE_COMPILE_DEFINITIONS "${llvm_definitions_list}"
+  IMPORTED_LOCATION "${LLVM_ROOT_DIR}/lib/libclang${CMAKE_STATIC_LIBRARY_SUFFIX}"
+  IMPORTED_LINK_INTERFACE_LIBRARIES "${deps_libs}"
+)

--- a/libclang/libclang-urls.txt
+++ b/libclang/libclang-urls.txt
@@ -1,0 +1,3 @@
+APPLE;https://download.qt.io/development_releases/prebuilt/libclang/qt/libclang-release_15.0.0-based-mac.7z;8a944b4b65d2dca883fe539af5e5eef9a67e2abca91b28258fb08c46e3bb05b6
+WIN32;https://download.qt.io/development_releases/prebuilt/libclang/qt/libclang-release_15.0.0-based-windows-vs2019_64.7z;3cd73b31be503ec7281f1f8907f95392d1c8bd0a8c2c92c39dc177f8c3d02baf
+LINUX;https://download.qt.io/development_releases/prebuilt/libclang/qt/libclang-release_15.0.0-based-linux-Ubuntu20.04-gcc9.3-x86_64.7z;0cfdf3387b8917e99fbd81358a142daeb3bcb84c107c96f1508f257ee2082bda

--- a/licenses.py
+++ b/licenses.py
@@ -2,10 +2,12 @@
 # Execute "conan install . --output-folder=.conan-install --deployer=licenses --build=missing"
 # or use "./build.py conan-install"
 
-from conan.tools.files import load, copy
+from conan.tools.files import load, copy, download
 from pathlib import Path
 import logging
 
+llvm_version = "15.0.0"
+llvm_license_url = f"https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-{llvm_version}/clang/LICENSE.TXT"
 
 def deploy(graph, output_folder, **kwargs):
     licenses_dir = Path(output_folder) / "licenses"
@@ -22,3 +24,7 @@ def deploy(graph, output_folder, **kwargs):
     ocls_output.mkdir(exist_ok=True, parents=True)
     logging.info(f"Copy '{root_dir}/LICENSE' to '{ocls_output}'")
     copy(graph.root.conanfile, "LICENSE", root_dir, ocls_output)
+
+    llvm_output = licenses_dir / "llvm" / llvm_version
+    llvm_output.mkdir(exist_ok=True, parents=True)
+    download(graph.root.conanfile, llvm_license_url, llvm_output / "LICENSE.TXT")

--- a/profiles/windows.common
+++ b/profiles/windows.common
@@ -3,6 +3,6 @@
 [settings]
 compiler=msvc
 compiler.cppstd=17
-compiler.runtime=static
+compiler.runtime=dynamic
 compiler.version=193
 os=Windows

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -10,6 +10,7 @@
 #include "log.hpp"
 #include "utils.hpp"
 
+#include <clang-c/Index.h>
 #include <filesystem>
 #include <iostream>
 #include <optional>
@@ -258,6 +259,8 @@ std::optional<ocls::Device> Diagnostics::SelectOpenCLDevice(
 
 std::string Diagnostics::BuildSource(const std::string& source) const
 {
+    clang_createIndex(0, 0); // tmp
+
     if (!m_device.has_value())
     {
         throw std::runtime_error("missing OpenCL device");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 target_compile_definitions(${TESTS_PROJECT_NAME} PRIVATE 
     ENABLE_TESTING=1
 )
-target_link_libraries (${TESTS_PROJECT_NAME} ${libs})
+target_link_libraries (${TESTS_PROJECT_NAME} ${libs} libclang-imported)
 target_include_directories(${TESTS_PROJECT_NAME} PRIVATE 
     "${PROJECT_SOURCE_DIR}/include"
     "${CMAKE_CURRENT_SOURCE_DIR}/mocks"

--- a/tests/mocks/clinfo-mock.hpp
+++ b/tests/mocks/clinfo-mock.hpp
@@ -5,6 +5,8 @@
 //  Created by Ilia Shoshin on 14/8/23.
 //
 
+#pragma once
+
 #include "clinfo.hpp"
 
 #include <gmock/gmock.h>

--- a/tests/mocks/diagnostics-mock.hpp
+++ b/tests/mocks/diagnostics-mock.hpp
@@ -5,6 +5,8 @@
 //  Created by Ilia Shoshin on 7/25/23.
 //
 
+#pragma once
+
 #include "diagnostics.hpp"
 
 #include <gmock/gmock.h>

--- a/tests/mocks/exit-handler-mock.hpp
+++ b/tests/mocks/exit-handler-mock.hpp
@@ -5,6 +5,7 @@
 //  Created by Ilia Shoshin on 8/03/23.
 //
 
+#pragma once
 
 #include "utils.hpp"
 

--- a/tests/mocks/generator-mock.hpp
+++ b/tests/mocks/generator-mock.hpp
@@ -5,6 +5,7 @@
 //  Created by Ilia Shoshin on 7/30/23.
 //
 
+#pragma once
 
 #include "utils.hpp"
 

--- a/tests/mocks/jsonrpc-mock.hpp
+++ b/tests/mocks/jsonrpc-mock.hpp
@@ -5,6 +5,8 @@
 //  Created by Ilia Shoshin on 7/25/23.
 //
 
+#pragma once
+
 #include "jsonrpc.hpp"
 
 #include <gmock/gmock.h>


### PR DESCRIPTION
This pull request integrates several key updates and improvements to the build and workflow processes. Notably, a dependency on `libclang` has been introduced, and several refinements have been made to the build and release workflows.

`libclang` is a significant dependency, essential for implementing certain advanced language server features (e.g., #17, [#48](https://github.com/Galarius/vscode-opencl/issues/48), kernel preprocessing). Unfortunately, there aren't any existing Conan 2.0-compatible recipes to incorporate it. As a result, it was decided to download prebuilt static libraries hosted by the Qt community. Cmake is responsible for the acquisition of the prebuilt static libraries during the configuration stage.

### Details:

- **Libclang Integration**:
  - Introduced a new dependency on `libclang`.
  - Implemented caching for `libclang` to enhance build performance/cost when using GitHub actions.
  - The step to create a Conan package in the build workflow has been removed (there's no need for a packaged language server, and this step consumes considerable time).
  - The default build type has been set to `Release`, as prebuilt libclang static libraries are available only for the `Release` configuration and this is crucial on Windows. Other platforms will also default to the `Release` configuration, especially since the package creation step was eliminated.
  - [win32] Updated Windows conan profiles to use the `dynamic` "compiler.runtime" setting to avoid mismatches when linking to libclang. Moreover, prebuilt conan packages are available for this configuration.
  - [linux] Added the `-no-pie` linker flag because the prebuilt `libclang` static library is position-dependent.
  
- **Other changes**:
  - Addressed potential header inclusion problems by adding the missing `#pragma once` directive.
